### PR TITLE
Fixed upgrade button not refreshing

### DIFF
--- a/client/scenes/SceneGame.js
+++ b/client/scenes/SceneGame.js
@@ -16,6 +16,7 @@ import { NotificationFlee } from "../src/NotificationFlee.js";
 import { NotificationQuest } from "../src/NotificationQuest.js";
 import { DayNotification } from "../src/DayNotification.js";
 import { ToolTip } from "../src/ToolTip.js";
+import { difficulty } from "./SceneLobby.js";
 
 
 // game variables ////////////////////////////////////////////////////////////////

--- a/client/scenes/SceneLobby.js
+++ b/client/scenes/SceneLobby.js
@@ -244,3 +244,5 @@ export function draw()
     if(sm.currentScene == sm.SCENE.lobby)
         requestAnimationFrame(draw);
 }
+
+export {difficulty}


### PR DESCRIPTION
Difficulty variable was not defined in `SceneGame.js`. This caused the socket listener `socket.on("facility"`)` in `SceneGame.js` to crash and unable to refresh upgrade facility button.

Fix: import difficulty variable from `SceneLobby.js`